### PR TITLE
Add many more image semantics and improve process for mapping other constants

### DIFF
--- a/src/WraithXCOD/WraithXCOD/CoDAssetType.cpp
+++ b/src/WraithXCOD/WraithXCOD/CoDAssetType.cpp
@@ -117,13 +117,15 @@ XMaterial_t::XMaterial_t(uint32_t ImageCount)
     Images.reserve(ImageCount);
 }
 
-XImage_t::XImage_t(ImageUsageType Usage, uint32_t Hash, uint64_t Pointer, const std::string& Name)
+XImage_t::XImage_t(ImageUsageType Usage, uint32_t Hash, uint32_t First, uint32_t Last, uint64_t Pointer, const std::string& Name)
 {
     // Defaults
     ImageUsage = Usage;
     ImagePtr = Pointer;
     ImageName = Name;
     SemanticHash = Hash;
+    FirstCharacter = First;
+    LastCharacter = Last;
 }
 
 XModelSubmesh_t::XModelSubmesh_t()

--- a/src/WraithXCOD/WraithXCOD/CoDAssetType.h
+++ b/src/WraithXCOD/WraithXCOD/CoDAssetType.h
@@ -264,7 +264,7 @@ enum class ImageUsageType : uint8_t
 struct XImage_t
 {
     // Constructor
-    XImage_t(ImageUsageType Usage, uint32_t Hash, uint64_t Pointer, const std::string& Name);
+    XImage_t(ImageUsageType Usage, uint32_t Hash, uint32_t First, uint32_t Last, uint64_t Pointer, const std::string& Name);
 
     // The usage of this image asset
     ImageUsageType ImageUsage;
@@ -272,6 +272,9 @@ struct XImage_t
     uint64_t ImagePtr;
 
     uint32_t SemanticHash;
+
+    uint32_t FirstCharacter;
+    uint32_t LastCharacter;
 
     // The name of this image asset
     std::string ImageName;

--- a/src/WraithXCOD/WraithXCOD/CoDAssets.cpp
+++ b/src/WraithXCOD/WraithXCOD/CoDAssets.cpp
@@ -405,8 +405,61 @@ std::map<uint32_t, std::string> SemanticHashes =
     { 0x95B48AE5, "meltRevealMap" },
     { 0x1DCB003F, "meltNormalMap" },
     { 0xB607C0FE, "Color_Map" },
+
+    { 0x27568B1F, "decalColorMap1" },
+    { 0x27568B1C, "decalColorMap2" },
+
+    { 0x5A7D8971, "decalNormalMap1" },
+
+    { 0xCC382E3A, "decalSpecColorMap1" },
+    { 0xCC382E39, "decalSpecColorMap2" },
+
+    { 0xBAE31156, "decalAlphaMap1" },
+    { 0xBAE31155, "decalAlphaMap2" },
+
+    { 0xCD7DF742, "envBrdFlut" },
+    { 0x7D3CDFB3, "envBrdFlut1" },
+
+    { 0x48D1074B, "displacementMap" },
+    { 0x62F1F09A, "displacementMap1" },
+    { 0x62F1F099, "displacementMap2" },
+    { 0x62F1F098, "displacementMap3" },
+    { 0x62F1F09F, "displacementMap4" },
+    { 0x62F1F09E, "displacementMap5" },
+    { 0x62F1F09D, "displacementMap6" },
+    { 0x62F1F09C, "displacementMap7" },
+    { 0x62F1F093, "displacementMap8" },
+
+    { 0xB60D1850, "colorMap1" },
+    { 0xB60D1853, "colorMap2" },
+    { 0xB60D1852, "colorMap3" },
+
+    { 0x9434AEDE, "normalMap1" },
+
     { 0x34ECCCB3, "specularMap" },
-    { 0x6001F931, "occlusionMap" }
+    { 0xD2866322, "specularMap1" },
+
+    { 0x6001F931, "occlusionMap" },
+    { 0x60411F60, "occlusionMap1" },
+
+    { 0x7389AC64, "heatMap" },
+
+    { 0xCFE18444, "revealMap1" },
+
+    { 0x38436E1C, "uvDistortMap" },
+
+    { 0xFFC5A8BB, "worldXyzNoiseMap" },
+
+    { 0xF2C66201, "envMap" },
+
+    { 0x44C0B99F, "tangentMap" },
+
+    { 0x103B5996, "cloakMap" },
+
+    { 0x197CA29E, "eyeAOTex" },
+    { 0x26FE83DC, "eyeIrradianceTex" },
+
+    { 0x546D65C7, "parallaxMap"}
 };
 
 // -- Find game information
@@ -1998,7 +2051,7 @@ ExportGameResult CoDAssets::ExportMaterialAsset(const CoDMaterial_t* Material, c
     // Process Image Names
     ExportMaterialImageNames(XMaterial, ExportPath);
     // Process the material
-    ExportMaterialImages(XMaterial, ExportPath, ImageExtension, ImageFormatType);
+    //ExportMaterialImages(XMaterial, ExportPath, ImageExtension, ImageFormatType);
 
     // Success, unless specific error
     return ExportGameResult::Success;
@@ -2191,7 +2244,14 @@ void CoDAssets::ExportMaterialImageNames(const XMaterial_t& Material, const std:
             }
             else
             {
-                ImageNames.WriteLineFmt("unk_semantic_0x%X,%s", Image.SemanticHash, Image.ImageName.c_str());
+                if (Image.FirstCharacter && Image.LastCharacter)
+                {
+                    ImageNames.WriteLineFmt("unk_semantic_0x%X,%i,%i,%s", Image.SemanticHash, Image.FirstCharacter, Image.LastCharacter, Image.ImageName.c_str());
+                }
+                else
+                {
+                    ImageNames.WriteLineFmt("unk_semantic_0x%X,%s", Image.SemanticHash, Image.ImageName.c_str());
+                }
             }
         }
 

--- a/src/WraithXCOD/WraithXCOD/CoDAssets.cpp
+++ b/src/WraithXCOD/WraithXCOD/CoDAssets.cpp
@@ -2051,7 +2051,7 @@ ExportGameResult CoDAssets::ExportMaterialAsset(const CoDMaterial_t* Material, c
     // Process Image Names
     ExportMaterialImageNames(XMaterial, ExportPath);
     // Process the material
-    //ExportMaterialImages(XMaterial, ExportPath, ImageExtension, ImageFormatType);
+    ExportMaterialImages(XMaterial, ExportPath, ImageExtension, ImageFormatType);
 
     // Success, unless specific error
     return ExportGameResult::Success;

--- a/src/WraithXCOD/WraithXCOD/DBGameAssets.h
+++ b/src/WraithXCOD/WraithXCOD/DBGameAssets.h
@@ -151,7 +151,12 @@ struct WAWXMaterial
 struct WAWXMaterialImage
 {
     uint32_t SemanticHash;
-    uint8_t Padding[8];
+    int8_t NameStart;
+    int8_t NameEnd;
+    uint8_t SamplerState;
+    uint8_t Semantic;
+    int8_t IsMatureContent;
+    uint8_t padding[3];
     uint32_t ImagePtr;
 };
 #pragma pack(pop)
@@ -349,7 +354,12 @@ struct BOXMaterial
 struct BOXMaterialImage
 {
     uint32_t SemanticHash;
-    uint8_t Padding[8];
+    int8_t NameStart;
+    int8_t NameEnd;
+    uint8_t SamplerState;
+    uint8_t Semantic;
+    int8_t IsMatureContent;
+    uint8_t padding[3];
     uint32_t ImagePtr;
 };
 #pragma pack(pop)
@@ -566,7 +576,12 @@ struct BO2XMaterial
 struct BO2XMaterialImage
 {
     uint32_t SemanticHash;
-    uint8_t Padding[8];
+    int8_t NameStart;
+    int8_t NameEnd;
+    uint8_t SamplerState;
+    uint8_t Semantic;
+    int8_t IsMatureContent;
+    uint8_t padding[3];
     uint32_t ImagePtr;
 };
 #pragma pack(pop)
@@ -1304,7 +1319,10 @@ struct MWXMaterial
 struct MWXMaterialImage
 {
     uint32_t SemanticHash;
-    uint8_t Padding[4];
+    int8_t NameStart;
+    int8_t NameEnd;
+    uint8_t samplerState;
+    uint8_t semantic;
     uint32_t ImagePtr;
 };
 #pragma pack(pop)
@@ -1485,7 +1503,10 @@ struct MW2XMaterial
 struct MW2XMaterialImage
 {
     uint32_t SemanticHash;
-    uint8_t Padding[4];
+    int8_t NameStart;
+    int8_t NameEnd;
+    uint8_t samplerState;
+    uint8_t semantic;
     uint32_t ImagePtr;
 };
 #pragma pack(pop)
@@ -1650,7 +1671,10 @@ struct MW3XMaterial
 struct MW3XMaterialImage
 {
     uint32_t SemanticHash;
-    uint8_t Padding[4];
+    int8_t NameStart;
+    int8_t NameEnd;
+    uint8_t samplerState;
+    uint8_t semantic;
     uint32_t ImagePtr;
 };
 #pragma pack(pop)
@@ -1840,7 +1864,10 @@ struct GhostsXMaterial
 struct GhostsXMaterialImage
 {
     uint32_t SemanticHash;
-    uint8_t Padding[4];
+    int8_t NameStart;
+    int8_t NameEnd;
+    uint8_t samplerState;
+    uint8_t semantic;
     uint64_t ImagePtr;
 };
 #pragma pack(pop)
@@ -2097,7 +2124,10 @@ struct AWXMaterial
 struct AWXMaterialImage
 {
     uint32_t SemanticHash;
-    uint8_t Padding[4];
+    int8_t NameStart;
+    int8_t NameEnd;
+    uint8_t samplerState;
+    uint8_t semantic;
     uint64_t ImagePtr;
 };
 #pragma pack(pop)
@@ -2379,7 +2409,10 @@ struct MWRXMaterial
 struct MWRXMaterialImage
 {
     uint32_t SemanticHash;
-    uint8_t Padding[4];
+    int8_t NameStart;
+    int8_t NameEnd;
+    uint8_t samplerState;
+    uint8_t semantic;
     uint64_t ImagePtr;
 };
 #pragma pack(pop)
@@ -2626,7 +2659,10 @@ struct IWXMaterial
 struct IWXMaterialImage
 {
     uint32_t SemanticHash;
-    uint8_t Padding[4];
+    int8_t NameStart;
+    int8_t NameEnd;
+    uint8_t samplerState;
+    uint8_t semantic;
     uint64_t ImagePtr;
 };
 #pragma pack(pop)
@@ -2836,7 +2872,10 @@ struct WWIIXMaterial
 struct WWIIXMaterialImage
 {
     uint32_t SemanticHash;
-    uint8_t Padding[4];
+    int8_t NameStart;
+    int8_t NameEnd;
+    uint8_t samplerState;
+    uint8_t semantic;
     uint64_t ImagePtr;
 };
 #pragma pack(pop)
@@ -3421,7 +3460,10 @@ struct MW4XMaterial
 struct MW4XMaterialImage
 {
     uint32_t Type;
-    uint8_t Padding[4];
+    int8_t NameStart;
+    int8_t NameEnd;
+    uint8_t samplerState;
+    uint8_t semantic;
     uint64_t ImagePtr;
 };
 #pragma pack(pop)

--- a/src/WraithXCOD/WraithXCOD/GameAdvancedWarfare.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameAdvancedWarfare.cpp
@@ -943,7 +943,7 @@ std::unique_ptr<XImageDDS> GameAdvancedWarfare::ReadXImage(const CoDImage_t* Ima
     // Proxy the image off, determine type if need be
     auto Usage = (Image->Format == 84) ? ImageUsageType::NormalMap : ImageUsageType::DiffuseMap;
     // Proxy off
-    return LoadXImage(XImage_t(Usage, 0, Image->AssetPointer, Image->AssetName));
+    return LoadXImage(XImage_t(Usage, 0, 0, 0, Image->AssetPointer, Image->AssetName));
 }
 
 const XMaterial_t GameAdvancedWarfare::ReadXMaterial(uint64_t MaterialPointer)
@@ -981,7 +981,7 @@ const XMaterial_t GameAdvancedWarfare::ReadXMaterial(uint64_t MaterialPointer)
         }
 
         // Assign the new image
-        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.ImagePtr, ImageName);
+        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.NameStart, ImageInfo.NameEnd, ImageInfo.ImagePtr, ImageName);
 
         // Advance
         MaterialData.ImageTablePtr += sizeof(AWXMaterialImage);

--- a/src/WraithXCOD/WraithXCOD/GameBlackOps.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameBlackOps.cpp
@@ -516,7 +516,7 @@ const XMaterial_t GameBlackOps::ReadXMaterial(uint64_t MaterialPointer)
         }
 
         // Assign the new image
-        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.ImagePtr, ImageName);
+        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.NameStart, ImageInfo.NameEnd, ImageInfo.ImagePtr, ImageName);
 
         // Advance
         MaterialData.ImageTablePtr += sizeof(BOXMaterialImage);

--- a/src/WraithXCOD/WraithXCOD/GameBlackOps2.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameBlackOps2.cpp
@@ -519,7 +519,7 @@ const XMaterial_t GameBlackOps2::ReadXMaterial(uint64_t MaterialPointer)
         }
 
         // Assign the new image
-        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.ImagePtr, ImageName);
+        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.NameStart, ImageInfo.NameEnd, ImageInfo.ImagePtr, ImageName);
 
         // Advance
         MaterialData.ImageTablePtr += sizeof(BO2XMaterialImage);

--- a/src/WraithXCOD/WraithXCOD/GameBlackOps3.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameBlackOps3.cpp
@@ -580,7 +580,7 @@ std::unique_ptr<XImageDDS> GameBlackOps3::ReadXImage(const CoDImage_t* Image)
     }
 
     // Proxy off
-    return LoadXImage(XImage_t(Usage, 0, Image->AssetPointer, Image->AssetName));
+    return LoadXImage(XImage_t(Usage, 0, 0, 0, Image->AssetPointer, Image->AssetName));
 }
 
 const XMaterial_t GameBlackOps3::ReadXMaterial(uint64_t MaterialPointer)
@@ -618,7 +618,7 @@ const XMaterial_t GameBlackOps3::ReadXMaterial(uint64_t MaterialPointer)
         }
 
         // Assign the new image
-        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.ImagePtr, ImageName);
+        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, 0, 0, ImageInfo.ImagePtr, ImageName);
 
         // Advance
         MaterialData.ImageTablePtr += sizeof(BO3XMaterialImage);

--- a/src/WraithXCOD/WraithXCOD/GameBlackOps4.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameBlackOps4.cpp
@@ -1220,7 +1220,7 @@ std::unique_ptr<XModel_t> GameBlackOps4::ReadXModel(const CoDModel_t* Model)
 std::unique_ptr<XImageDDS> GameBlackOps4::ReadXImage(const CoDImage_t* Image)
 {
     // Proxy off
-    return LoadXImage(XImage_t(ImageUsageType::DiffuseMap, 0, Image->AssetPointer, Image->AssetName));
+    return LoadXImage(XImage_t(ImageUsageType::DiffuseMap, 0, 0, 0, Image->AssetPointer, Image->AssetName));
 }
 
 const XMaterial_t GameBlackOps4::ReadXMaterial(uint64_t MaterialPointer)
@@ -1272,7 +1272,7 @@ const XMaterial_t GameBlackOps4::ReadXMaterial(uint64_t MaterialPointer)
         }
 
         // Assign the new image
-        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.ImagePtr, ImageName);
+        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, 0, 0, ImageInfo.ImagePtr, ImageName);
 
         // Advance
         MaterialData.ImageTablePtr += sizeof(BO4XMaterialImage);

--- a/src/WraithXCOD/WraithXCOD/GameBlackOpsCW.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameBlackOpsCW.cpp
@@ -813,7 +813,7 @@ std::unique_ptr<XModel_t> GameBlackOpsCW::ReadXModel(const CoDModel_t* Model)
 std::unique_ptr<XImageDDS> GameBlackOpsCW::ReadXImage(const CoDImage_t* Image)
 {
     // Proxy off
-    return LoadXImage(XImage_t(ImageUsageType::DiffuseMap, 0, Image->AssetPointer, Image->AssetName));
+    return LoadXImage(XImage_t(ImageUsageType::DiffuseMap, 0, 0, 0, Image->AssetPointer, Image->AssetName));
 }
 
 std::unique_ptr<XSound> GameBlackOpsCW::ReadXSound(const CoDSound_t * Sound)
@@ -1020,7 +1020,7 @@ const XMaterial_t GameBlackOpsCW::ReadXMaterial(uint64_t MaterialPointer)
         }
 
         // Assign the new image
-        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.ImagePtr, ImageName);
+        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, 0, 0, ImageInfo.ImagePtr, ImageName);
 
         // Advance
         MaterialData.ImageTablePtr += sizeof(BOCWXMaterialImage);

--- a/src/WraithXCOD/WraithXCOD/GameGhosts.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameGhosts.cpp
@@ -704,7 +704,7 @@ std::unique_ptr<XImageDDS> GameGhosts::ReadXImage(const CoDImage_t* Image)
     // Proxy the image off, determine type if need be
     auto Usage = (Image->Format == 84) ? ImageUsageType::NormalMap : ImageUsageType::DiffuseMap;
     // Proxy off
-    return LoadXImage(XImage_t(Usage, 0, Image->AssetPointer, Image->AssetName));
+    return LoadXImage(XImage_t(Usage, 0, 0, 0, Image->AssetPointer, Image->AssetName));
 }
 
 const XMaterial_t GameGhosts::ReadXMaterial(uint64_t MaterialPointer)
@@ -742,7 +742,7 @@ const XMaterial_t GameGhosts::ReadXMaterial(uint64_t MaterialPointer)
         }
 
         // Assign the new image
-        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.ImagePtr, ImageName);
+        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.NameStart, ImageInfo.NameEnd, ImageInfo.ImagePtr, ImageName);
 
         // Advance
         MaterialData.ImageTablePtr += sizeof(GhostsXMaterialImage);

--- a/src/WraithXCOD/WraithXCOD/GameInfiniteWarfare.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameInfiniteWarfare.cpp
@@ -672,9 +672,9 @@ std::unique_ptr<XImageDDS> GameInfiniteWarfare::ReadXImage(const CoDImage_t* Ima
     }
     // Proxy off
     if (ps::state != nullptr)
-        return LoadXImagePS(XImage_t(Usage, 0, Image->AssetPointer, Image->AssetName));
+        return LoadXImagePS(XImage_t(Usage, 0, 0, 0, Image->AssetPointer, Image->AssetName));
     else
-        return LoadXImage(XImage_t(Usage, 0, Image->AssetPointer, Image->AssetName));
+        return LoadXImage(XImage_t(Usage, 0, 0, 0, Image->AssetPointer, Image->AssetName));
 }
 
 const XMaterial_t GameInfiniteWarfare::ReadXMaterial(uint64_t MaterialPointer)
@@ -706,7 +706,7 @@ const XMaterial_t GameInfiniteWarfare::ReadXMaterial(uint64_t MaterialPointer)
         }
 
         // Assign the new image
-        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.ImagePtr, ImageName);
+        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.NameStart, ImageInfo.NameEnd, ImageInfo.ImagePtr, ImageName);
 
         // Advance
         MaterialData.ImageTablePtr += sizeof(IWXMaterialImage);

--- a/src/WraithXCOD/WraithXCOD/GameModernWarfare.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameModernWarfare.cpp
@@ -514,7 +514,7 @@ const XMaterial_t GameModernWarfare::ReadXMaterial(uint64_t MaterialPointer)
         }
 
         // Assign the new image
-        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.ImagePtr, ImageName);
+        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.NameStart, ImageInfo.NameEnd, ImageInfo.ImagePtr, ImageName);
 
         // Advance
         MaterialData.ImageTablePtr += sizeof(MWXMaterialImage);

--- a/src/WraithXCOD/WraithXCOD/GameModernWarfare2.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameModernWarfare2.cpp
@@ -516,7 +516,7 @@ const XMaterial_t GameModernWarfare2::ReadXMaterial(uint64_t MaterialPointer)
         }
 
         // Assign the new image
-        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.ImagePtr, ImageName);
+        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.NameStart, ImageInfo.NameEnd, ImageInfo.ImagePtr, ImageName);
 
         // Advance
         MaterialData.ImageTablePtr += sizeof(MW2XMaterialImage);

--- a/src/WraithXCOD/WraithXCOD/GameModernWarfare2RM.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameModernWarfare2RM.cpp
@@ -998,9 +998,9 @@ std::unique_ptr<XImageDDS> GameModernWarfare2RM::ReadXImage(const CoDImage_t* Im
     }
     // Proxy off
     if (ps::state != nullptr)
-        return LoadXImagePS(XImage_t(Usage, 0, Image->AssetPointer, Image->AssetName));
+        return LoadXImagePS(XImage_t(Usage, 0, 0, 0, Image->AssetPointer, Image->AssetName));
     else
-        return LoadXImage(XImage_t(Usage, 0, Image->AssetPointer, Image->AssetName));
+        return LoadXImage(XImage_t(Usage, 0, 0, 0, Image->AssetPointer, Image->AssetName));
 }
 
 struct XImageData
@@ -1145,7 +1145,7 @@ const XMaterial_t GameModernWarfare2RM::ReadXMaterial(uint64_t MaterialPointer)
         }
 
         // Assign the new image
-        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.ImagePtr, ImageName);
+        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.NameStart, ImageInfo.NameEnd, ImageInfo.ImagePtr, ImageName);
 
         // Advance
         MaterialData.ImageTablePtr += sizeof(MWRXMaterialImage);

--- a/src/WraithXCOD/WraithXCOD/GameModernWarfare3.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameModernWarfare3.cpp
@@ -517,7 +517,7 @@ const XMaterial_t GameModernWarfare3::ReadXMaterial(uint64_t MaterialPointer)
         }
 
         // Assign the new image
-        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.ImagePtr, ImageName);
+        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.NameStart, ImageInfo.NameEnd, ImageInfo.ImagePtr, ImageName);
 
         // Advance
         MaterialData.ImageTablePtr += sizeof(MW3XMaterialImage);

--- a/src/WraithXCOD/WraithXCOD/GameModernWarfare4.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameModernWarfare4.cpp
@@ -585,7 +585,7 @@ std::unique_ptr<XModel_t> GameModernWarfare4::ReadXModel(const CoDModel_t* Model
 std::unique_ptr<XImageDDS> GameModernWarfare4::ReadXImage(const CoDImage_t* Image)
 {
     // Proxy off
-    return LoadXImage(XImage_t(ImageUsageType::DiffuseMap, 0, Image->AssetPointer, Image->AssetName));
+    return LoadXImage(XImage_t(ImageUsageType::DiffuseMap, 0, 0, 0, Image->AssetPointer, Image->AssetName));
 }
 
 void GameModernWarfare4::TranslateRawfile(const CoDRawFile_t * Rawfile, const std::string & ExportPath)
@@ -687,7 +687,7 @@ const XMaterial_t GameModernWarfare4::ReadXMaterial(uint64_t MaterialPointer)
         }
 
         // Assign the new image
-        Result.Images.emplace_back(DefaultUsage, ImageInfo.Type, ImageInfo.ImagePtr, ImageName);
+        Result.Images.emplace_back(DefaultUsage, ImageInfo.Type, 0, 0, ImageInfo.ImagePtr, ImageName);
 
         // Advance
         MaterialData.ImageTablePtr += sizeof(IWXMaterialImage);

--- a/src/WraithXCOD/WraithXCOD/GameModernWarfare5.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameModernWarfare5.cpp
@@ -627,7 +627,7 @@ std::unique_ptr<XModel_t> GameModernWarfare5::ReadXModel(const CoDModel_t* Model
 std::unique_ptr<XImageDDS> GameModernWarfare5::ReadXImage(const CoDImage_t* Image)
 {
     // Proxy off
-    return LoadXImage(XImage_t(ImageUsageType::DiffuseMap, 0, Image->AssetPointer, Image->AssetName));
+    return LoadXImage(XImage_t(ImageUsageType::DiffuseMap, 0, 0, 0, Image->AssetPointer, Image->AssetName));
 }
 
 std::unique_ptr<XSound> GameModernWarfare5::ReadXSound(const CoDSound_t* Sound)
@@ -743,7 +743,7 @@ const XMaterial_t GameModernWarfare5::ReadXMaterial(uint64_t MaterialPointer)
             }
 
             // Assign the new image
-            Result.Images.emplace_back(DefaultUsage, ImageInfo.Type, ImageInfo.ImagePtr, ImageName);
+            Result.Images.emplace_back(DefaultUsage, ImageInfo.Type, 0, 0, ImageInfo.ImagePtr, ImageName);
 
             // Advance
             MaterialData.ImageTablePtr += sizeof(IWXMaterialImage);
@@ -781,7 +781,7 @@ const XMaterial_t GameModernWarfare5::ReadXMaterial(uint64_t MaterialPointer)
             }
 
             // Assign the new image
-            Result.Images.emplace_back(DefaultUsage, ImageInfo.Type, ImageInfo.ImagePtr, ImageName);
+            Result.Images.emplace_back(DefaultUsage, ImageInfo.Type, 0, 0, ImageInfo.ImagePtr, ImageName);
 
             // Advance
             MaterialData.ImageTablePtr += sizeof(IWXMaterialImage);

--- a/src/WraithXCOD/WraithXCOD/GameModernWarfareRM.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameModernWarfareRM.cpp
@@ -1014,9 +1014,9 @@ std::unique_ptr<XImageDDS> GameModernWarfareRM::ReadXImage(const CoDImage_t* Ima
     }
     // Proxy off
     if(ps::state != nullptr)
-        return LoadXImagePS(XImage_t(Usage, 0, Image->AssetPointer, Image->AssetName));
+        return LoadXImagePS(XImage_t(Usage, 0, 0, 0, Image->AssetPointer, Image->AssetName));
     else
-        return LoadXImage(XImage_t(Usage, 0, Image->AssetPointer, Image->AssetName));
+        return LoadXImage(XImage_t(Usage, 0, 0, 0, Image->AssetPointer, Image->AssetName));
 }
 
 XMaterial_t GameModernWarfareRM::ReadXMaterial(uint64_t MaterialPointer)
@@ -1055,7 +1055,7 @@ XMaterial_t GameModernWarfareRM::ReadXMaterial(uint64_t MaterialPointer)
         }
 
         // Assign the new image
-        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.ImagePtr, ImageName);
+        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.NameStart, ImageInfo.NameEnd, ImageInfo.ImagePtr, ImageName);
 
         // Advance
         MaterialData.ImageTablePtr += sizeof(MWRXMaterialImage);

--- a/src/WraithXCOD/WraithXCOD/GameQuantumSolace.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameQuantumSolace.cpp
@@ -497,7 +497,7 @@ const XMaterial_t GameQuantumSolace::ReadXMaterial(uint64_t MaterialPointer)
         }
 
         // Assign the new image
-        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.ImagePtr, ImageName);
+        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.NameStart, ImageInfo.NameEnd, ImageInfo.ImagePtr, ImageName);
 
         // Advance
         MaterialData.ImageTablePtr += sizeof(MWXMaterialImage);

--- a/src/WraithXCOD/WraithXCOD/GameVanguard.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameVanguard.cpp
@@ -687,7 +687,7 @@ std::unique_ptr<XModel_t> GameVanguard::ReadXModel(const CoDModel_t* Model)
 std::unique_ptr<XImageDDS> GameVanguard::ReadXImage(const CoDImage_t* Image)
 {
     // Proxy off
-    return LoadXImage(XImage_t(ImageUsageType::DiffuseMap, 0, Image->AssetPointer, Image->AssetName));
+    return LoadXImage(XImage_t(ImageUsageType::DiffuseMap, 0, 0, 0, Image->AssetPointer, Image->AssetName));
 }
 
 std::unique_ptr<XSound> GameVanguard::ReadXSound(const CoDSound_t* Sound)
@@ -826,7 +826,7 @@ const XMaterial_t GameVanguard::ReadXMaterial(uint64_t MaterialPointer)
         }
 
         // Assign the new image
-        Result.Images.emplace_back(DefaultUsage, ImageInfo.Type, ImageInfo.ImagePtr, ImageName);
+        Result.Images.emplace_back(DefaultUsage, ImageInfo.Type, 0, 0, ImageInfo.ImagePtr, ImageName);
 
         // Advance
         MaterialData.ImageTablePtr += sizeof(IWXMaterialImage);

--- a/src/WraithXCOD/WraithXCOD/GameWorldAtWar.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameWorldAtWar.cpp
@@ -510,7 +510,7 @@ const XMaterial_t GameWorldAtWar::ReadXMaterial(uint64_t MaterialPointer)
         }
 
         // Assign the new image
-        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.ImagePtr, ImageName);
+        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.NameStart, ImageInfo.NameEnd, ImageInfo.ImagePtr, ImageName);
 
         // Advance
         MaterialData.ImageTablePtr += sizeof(WAWXMaterialImage);

--- a/src/WraithXCOD/WraithXCOD/GameWorldWar2.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameWorldWar2.cpp
@@ -629,7 +629,7 @@ std::unique_ptr<XImageDDS> GameWorldWar2::ReadXImage(const CoDImage_t* Image)
         Usage = ImageUsageType::NormalMap;
     }
     // Proxy off
-    return LoadXImage(XImage_t(Usage, 0, Image->AssetPointer, Image->AssetName));
+    return LoadXImage(XImage_t(Usage, 0, 0, 0, Image->AssetPointer, Image->AssetName));
 }
 
 std::unique_ptr<XSound> GameWorldWar2::ReadXSound(const CoDSound_t* Sound)
@@ -865,7 +865,7 @@ const XMaterial_t GameWorldWar2::ReadXMaterial(uint64_t MaterialPointer)
         }
 
         // Assign the new image
-        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.ImagePtr, ImageName);
+        Result.Images.emplace_back(DefaultUsage, ImageInfo.SemanticHash, ImageInfo.NameStart, ImageInfo.NameEnd, ImageInfo.ImagePtr, ImageName);
 
         // Advance
         MaterialData.ImageTablePtr += sizeof(WWIIXMaterialImage);


### PR DESCRIPTION
I've added more image semantics from Modern Warfare Remastered and other IW engine games.

I've also changed the unk_semantic to include the "FirstCharacter" and "LastCharacter". These are as it sounds: the first and last character of the semantic which can then be used to brute force the other semantics.