### PR TITLE
Disable windows maximum path length limitation and adapt to MW2022 hash table

### DIFF
--- a/src/WraithXCOD/WraithXCOD/GameModernWarfare5.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameModernWarfare5.cpp
@@ -206,6 +206,8 @@ bool GameModernWarfare5::LoadAssets()
             {
                 // Read
                 auto MatResult = CoDAssets::GameInstance->Read<MW5XMaterialSP>(Asset.Header);
+                // Mask the name as hashes are 60Bit (Actually 63Bit but maintain with our existing tables)
+                MatResult.Hash &= 0xFFFFFFFFFFFFFFF;
 
                 std::string MaterialName;
 
@@ -233,6 +235,8 @@ bool GameModernWarfare5::LoadAssets()
             {
                 // Read
                 auto MatResult = CoDAssets::GameInstance->Read<MW5XMaterial>(Asset.Header);
+                // Mask the name as hashes are 60Bit (Actually 63Bit but maintain with our existing tables)
+                MatResult.Hash &= 0xFFFFFFFFFFFFFFF;
                 // Validate and load if need be
                 auto MaterialName = CoDAssets::GetHashedName("xmaterial", MatResult.Hash);
 
@@ -715,6 +719,8 @@ const XMaterial_t GameModernWarfare5::ReadXMaterial(uint64_t MaterialPointer)
     {
         // Prepare to parse the material
         auto MaterialData = CoDAssets::GameInstance->Read<MW5XMaterialSP>(MaterialPointer);
+        // Mask the name as hashes are 60Bit (Actually 63Bit but maintain with our existing tables)
+        MaterialData.Hash &= 0xFFFFFFFFFFFFFFF;
 
         // Allocate a new material with the given image count
         XMaterial_t Result(MaterialData.ImageCount);
@@ -730,7 +736,7 @@ const XMaterial_t GameModernWarfare5::ReadXMaterial(uint64_t MaterialPointer)
             // Read the image info
             auto ImageInfo = CoDAssets::GameInstance->Read<MW5XMaterialImage>(MaterialData.ImageTablePtr);
             // Read the image name (End of image - 8)
-            auto ImageName = CoDAssets::GetHashedName("ximage", CoDAssets::GameInstance->Read<uint64_t>(ImageInfo.ImagePtr));
+            auto ImageName = CoDAssets::GetHashedName("ximage", CoDAssets::GameInstance->Read<uint64_t>(ImageInfo.ImagePtr) & 0xFFFFFFFFFFFFFFF);
 
             // Default type
             auto DefaultUsage = ImageUsageType::Unknown;
@@ -756,6 +762,8 @@ const XMaterial_t GameModernWarfare5::ReadXMaterial(uint64_t MaterialPointer)
     {
         // Prepare to parse the material
         auto MaterialData = CoDAssets::GameInstance->Read<MW5XMaterial>(MaterialPointer);
+        // Mask the name as hashes are 60Bit (Actually 63Bit but maintain with our existing tables)
+        MaterialData.Hash &= 0xFFFFFFFFFFFFFFF;
 
         // Allocate a new material with the given image count
         XMaterial_t Result(MaterialData.ImageCount);
@@ -768,7 +776,7 @@ const XMaterial_t GameModernWarfare5::ReadXMaterial(uint64_t MaterialPointer)
             // Read the image info
             auto ImageInfo = CoDAssets::GameInstance->Read<MW5XMaterialImage>(MaterialData.ImageTablePtr);
             // Read the image name (End of image - 8)
-            auto ImageName = CoDAssets::GetHashedName("ximage", CoDAssets::GameInstance->Read<uint64_t>(ImageInfo.ImagePtr));
+            auto ImageName = CoDAssets::GetHashedName("ximage", CoDAssets::GameInstance->Read<uint64_t>(ImageInfo.ImagePtr) & 0xFFFFFFFFFFFFFFF);
 
             // Default type
             auto DefaultUsage = ImageUsageType::Unknown;
@@ -1455,6 +1463,8 @@ void GameModernWarfare5::PerformInitialSetup()
     CoDAssets::StringCache.LoadIndex(FileSystems::CombinePath(FileSystems::GetApplicationPath(), "package_index\\fnv1a_string.wni"));
     CoDAssets::StringCache.LoadIndex(FileSystems::CombinePath(FileSystems::GetApplicationPath(), "package_index\\fnv1a_bones.wni"));
     CoDAssets::AssetNameCache.LoadIndex(FileSystems::CombinePath(FileSystems::GetApplicationPath(), "package_index\\fnv1a_xsounds_unverified.wni"));
+    CoDAssets::AssetNameCache.LoadIndex(FileSystems::CombinePath(FileSystems::GetApplicationPath(), "package_index\\fnv_ximages.wni"));
+    CoDAssets::AssetNameCache.LoadIndex(FileSystems::CombinePath(FileSystems::GetApplicationPath(), "package_index\\fnv_xmaterials.wni"));
 
     // Copy if not exists
     if (!FileSystems::FileExists(OurPath))

--- a/src/WraithXCOD/WraithXCOD/WraithXCOD.manifest
+++ b/src/WraithXCOD/WraithXCOD/WraithXCOD.manifest
@@ -1,0 +1,9 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+ ...
+  <asmv3:application>
+    <asmv3:windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+      <ws2:longPathAware>true</ws2:longPathAware>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+ ...
+</assembly>

--- a/src/WraithXCOD/WraithXCOD/WraithXCOD.vcxproj
+++ b/src/WraithXCOD/WraithXCOD/WraithXCOD.vcxproj
@@ -59,6 +59,9 @@
       <AdditionalDependencies>opengl32.lib;glu32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>AsInvoker</UACExecutionLevel>
     </Link>
+    <Manifest>
+      <AdditionalManifestFiles>WraithXCOD.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -79,6 +82,9 @@
       <AdditionalDependencies>opengl32.lib;glu32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>AsInvoker</UACExecutionLevel>
     </Link>
+    <Manifest>
+      <AdditionalManifestFiles>WraithXCOD.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\External\CascLib-2.1\CascLib_vs19.vcxproj">
@@ -250,6 +256,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="cpp.hint" />
+  </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="WraithXCOD.manifest" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/WraithXCOD/WraithXCOD/WraithXCOD.vcxproj.filters
+++ b/src/WraithXCOD/WraithXCOD/WraithXCOD.vcxproj.filters
@@ -487,4 +487,7 @@
   <ItemGroup>
     <None Include="cpp.hint" />
   </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="WraithXCOD.manifest" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Disable windows maximum path length limitation and adapt to MW2022 hash table