### PR TITLE
Fixes a crash with vanguard hashed sounds, as well as preventing a memory leak in GameBlackOps4.cpp (heap allocation never cleared)

### DIFF
--- a/src/WraithXCOD/WraithXCOD/GameBlackOps4.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameBlackOps4.cpp
@@ -21,7 +21,7 @@ WraithNameIndex GameBlackOps4::AssetNameCache = WraithNameIndex();
 
 // -- Initialize Decryption Table
 
-uint32_t* DecryptionTable = new uint32_t[4082]
+uint32_t DecryptionTable[4082]
 {
     0x024FCAAE, 0x02E543B3, 0x001C94DD, 0x051D15E4, 0x00FB831A, 0x01E16CA9, 0x0285BE0A, 0x05910248,
     0x022CDDE4, 0x05C224AE, 0x00A9ADC0, 0x00B04EB8, 0x037AC36C, 0x05E6572A, 0x00486B19, 0x01049B4E,

--- a/src/WraithXCOD/WraithXCOD/GameVanguard.cpp
+++ b/src/WraithXCOD/WraithXCOD/GameVanguard.cpp
@@ -387,7 +387,7 @@ bool GameVanguard::LoadAssets()
 
 
                     // Log it
-                    CoDAssets::LogXAsset("Sound", NameResult->second);
+                    CoDAssets::LogXAsset("Sound", FileSystems::CombinePath(LoadedSound->FullPath, LoadedSound->AssetName));
 
 #if _DEBUG
                     Writer.WriteLineFmt("%llx,%s", Entry.Key, FileSystems::CombinePath(LoadedSound->FullPath, LoadedSound->AssetName));


### PR DESCRIPTION
- [Vanguard hashed sounds, NameResult->second never gets assigned, which causes a crash. This commit stops the crash while loading vanguard sounds.](https://github.com/Scobalula/Greyhound/pull/51/commits/03a6c9796f9a5925a06d9e9a48b3184e997a6683)
- [delete[] is also never called for DecryptionTable, which is heap allocated and wont automatically delete when out of scope, so will leak. Does not seem to be used outside of GameBlackOps4.cpp, removing the allocation with the new keyword, stops this memory leak and doesn't seem to break any of the functionality of it.](https://github.com/Scobalula/Greyhound/pull/51/commits/222db848160b65f160fdc1db24a727b6ceedfac3)