### PR TITLE
Fix face export order for Cast (CW -> CCW)

### DIFF
--- a/src/WraithX/WraithX/CastExport.cpp
+++ b/src/WraithX/WraithX/CastExport.cpp
@@ -166,17 +166,17 @@ void Cast::ExportCastModel(const WraithModel& Model, const std::string& FileName
 			switch (FaceIndexType)
 			{
 			case CastPropertyId::Byte:
-				FaceIndices->Write((uint8_t)Face.Index1);
+				FaceIndices->Write((uint8_t)Face.Index3);
 				FaceIndices->Write((uint8_t)Face.Index2);
-				FaceIndices->Write((uint8_t)Face.Index3); break;
+				FaceIndices->Write((uint8_t)Face.Index1); break;
 			case CastPropertyId::Short:
-				FaceIndices->Write((uint16_t)Face.Index1);
+				FaceIndices->Write((uint16_t)Face.Index3);
 				FaceIndices->Write((uint16_t)Face.Index2);
-				FaceIndices->Write((uint16_t)Face.Index3); break;
+				FaceIndices->Write((uint16_t)Face.Index1); break;
 			case CastPropertyId::Integer32:
-				FaceIndices->Write((uint32_t)Face.Index1);
+				FaceIndices->Write((uint32_t)Face.Index3);
 				FaceIndices->Write((uint32_t)Face.Index2);
-				FaceIndices->Write((uint32_t)Face.Index3); break;
+				FaceIndices->Write((uint32_t)Face.Index1); break;
 			}
 		}
 


### PR DESCRIPTION
Fixes CAST model exports to have the correct face order for models (Cast expects CCW winding faces - Greyhound currently exports CW) - turning this:
![image](https://github.com/Scobalula/Greyhound/assets/3669134/453dbe6b-a574-40b0-83a6-059567acf0da)
to this:
![image](https://github.com/Scobalula/Greyhound/assets/3669134/4573bd38-bd73-4f9a-9111-fef9aab70476)
